### PR TITLE
fix justdoit not working at all

### DIFF
--- a/justdoit.sh
+++ b/justdoit.sh
@@ -43,7 +43,7 @@ do
 	((total++))
 	tid=$(basename -s .in $tid)
 	./$exename < tests/$tid.in > tests/$tid.myout
-	diff -y tests/$tid.myout tests/$tid.out > tests/$tid.diff # original didn't use -u but ok
+	diff -y --suppress-common-lines tests/$tid.myout tests/$tid.out > tests/$tid.diff # original didn't use -u but ok
 	
 	if [ "$(wc -l < tests/$tid.diff)" -eq 0 ]; then
 		status="${GREEN}PASSED${NC}"


### PR DESCRIPTION
oops

changing to diff -y stopped it from working because now all lines are included
added --suppress-common-lines

alternative was to use the diff command's exit code but including ALL THE LINES in the .diff seems a bit too much anyway?

don't know what people prefer but right now justdoit is not working at all